### PR TITLE
Fix bug on the sign-in button

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -87,7 +87,7 @@ const toggleSignInButtons = (checkboxSelector, buttonSelector) => {
     $(checkboxSelector).prop('checked', false);
     $(buttonSelector).prop('disabled', true);
 
-    $(checkboxSelector).on('click', () => {
+    $(checkboxSelector).on('click', function () {
         $(buttonSelector).prop('disabled', !$(this).prop('checked'));
     });
 };


### PR DESCRIPTION
Fix the sign-in button that still disabled even after clicking to the terms checkbox.